### PR TITLE
Upgrade FILLR SDK version and other dependencies

### DIFF
--- a/project/app/build.gradle
+++ b/project/app/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.application'
 
 android {
 
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    compileSdkVersion 32
+    buildToolsVersion '31.0.0'
     defaultConfig {
         versionCode 1
         versionName "1.0"
         applicationId "com.fillr.example.integration"
-        minSdkVersion 18
-        targetSdkVersion 29
+        minSdkVersion 24
+        targetSdkVersion 32
         multiDexEnabled true
     }
 
@@ -36,8 +36,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = 1.7
-        targetCompatibility = 1.7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    packagingOptions {
+        exclude("META-INF/*.kotlin_module")
     }
 }
 
@@ -46,5 +49,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'com.fillr:fillrcore-fillrembeddedlite:8.7.8'
+    implementation 'com.fillr:fillrcore-fillrembeddedlite:9.1.0'
 }

--- a/project/build.gradle
+++ b/project/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.kotlinVersion = '1.8.10'
 
     repositories {
         google()
@@ -18,7 +19,15 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenLocal()
+        mavenCentral()
+        maven {
+            url "https://fillr.jfrog.io/artifactory/fillr-android-sdk/"
+            credentials {
+                username = "diptesh.patel" // Contact Fillr for username and password
+                password = "wocvef-6Dakna-jimtim"
+            }
+        }
     }
 }
 

--- a/project/gradle.properties
+++ b/project/gradle.properties
@@ -18,3 +18,4 @@ org.gradle.jvmargs=-Xmx1536m
 
 android.useAndroidX=true
 android.enableJetifier=true
+android.jetifier.blacklist=.*datadog.*


### PR DESCRIPTION
- Bumped the FILLR SDK version to 9.1.0
- Bumped targetsdk version and minsdk version
- Added justifier to blacklist Datadog library in grade.properties
- Needed to add packaging options to exclude *.kotlin_module as it was creating conflicts. 